### PR TITLE
feat: enhance README with brand visuals and flow diagram (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/❌_No_Receipt-No_Merge-red?style=for-the-badge" alt="No Receipt = No Merge">
+  <img src="./assets/gate-blocked.svg" alt="Deploy Gate blocked symbol" width="120">
+</p>
+
+<p align="center">
+  <strong>No receipt. No merge.</strong>
 </p>
 
 <h1 align="center">Deploy Gate</h1>
@@ -28,6 +32,25 @@
   <img src="https://img.shields.io/badge/Repos_Protected-3-blueviolet?style=flat-square" alt="Repos Protected">
   <img src="https://img.shields.io/badge/Approvals_Issued-12-blue?style=flat-square" alt="Approvals Issued">
 </p>
+
+---
+
+## Badge Usage
+
+<p align="left">
+  <img src="./assets/badge-blocked.svg" alt="deploy gate blocked badge">
+  <img src="./assets/badge-approved.svg" alt="deploy gate approved badge">
+</p>
+
+<p align="left">
+  <img src="./assets/gate-blocked.svg" alt="blocked gate symbol" width="52">
+  <img src="./assets/gate-signed.svg" alt="approved gate symbol" width="52">
+</p>
+
+```markdown
+![deploy gate blocked](./assets/badge-blocked.svg)
+![deploy gate approved](./assets/badge-approved.svg)
+```
 
 ---
 
@@ -71,6 +94,10 @@ jobs:
 ---
 
 ## How It Works
+
+<p align="left">
+  <img src="./assets/flow-diagram.svg" alt="PR Created to Deploy Gate flow">
+</p>
 
 ```
    PR opened → changes deploy/ or .github/workflows/

--- a/assets/badge-approved.svg
+++ b/assets/badge-approved.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="246" height="20" role="img" aria-label="deploy gate: approved">
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity="0.7"/>
+    <stop offset="0.1" stop-color="#aaa" stop-opacity="0.1"/>
+    <stop offset="0.9" stop-opacity="0.3"/>
+    <stop offset="1" stop-opacity="0.5"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="246" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="110" height="20" fill="#0a0a0a"/>
+    <rect x="110" width="136" height="20" fill="#44aa99"/>
+    <rect width="246" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="56" y="15" fill="#010101" fill-opacity="0.3">deploy gate</text>
+    <text x="56" y="14">deploy gate</text>
+    <text x="178" y="15" fill="#010101" fill-opacity="0.3">approved</text>
+    <text x="178" y="14">approved</text>
+  </g>
+</svg>

--- a/assets/badge-blocked.svg
+++ b/assets/badge-blocked.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="20" role="img" aria-label="deploy gate: blocked">
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity="0.7"/>
+    <stop offset="0.1" stop-color="#aaa" stop-opacity="0.1"/>
+    <stop offset="0.9" stop-opacity="0.3"/>
+    <stop offset="1" stop-opacity="0.5"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="240" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="110" height="20" fill="#0a0a0a"/>
+    <rect x="110" width="130" height="20" fill="#aa4455"/>
+    <rect width="240" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="56" y="15" fill="#010101" fill-opacity="0.3">deploy gate</text>
+    <text x="56" y="14">deploy gate</text>
+    <text x="176" y="15" fill="#010101" fill-opacity="0.3">blocked</text>
+    <text x="176" y="14">blocked</text>
+  </g>
+</svg>

--- a/assets/flow-diagram.svg
+++ b/assets/flow-diagram.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="250" viewBox="0 0 980 250" role="img" aria-labelledby="title desc">
+  <title id="title">Deploy Gate Flow</title>
+  <desc id="desc">Pull request creation flows into deploy gate; no receipt is blocked and valid receipt is approved.</desc>
+  <defs>
+    <style>
+      .label { font: 600 18px Arial, sans-serif; fill: #0a0a0a; }
+      .small { font: 700 16px Arial, sans-serif; fill: #ffffff; }
+      .arrow { stroke: #0a0a0a; stroke-width: 3; fill: none; marker-end: url(#arrowhead); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#0a0a0a"/>
+    </marker>
+  </defs>
+
+  <rect x="20" y="70" width="230" height="110" rx="12" fill="#ffffff" stroke="#0a0a0a" stroke-width="3"/>
+  <text x="135" y="134" text-anchor="middle" class="label">PR Created</text>
+
+  <rect x="374" y="70" width="230" height="110" rx="12" fill="#ffffff" stroke="#0a0a0a" stroke-width="3"/>
+  <text x="489" y="124" text-anchor="middle" class="label">Deploy Gate</text>
+  <text x="489" y="149" text-anchor="middle" class="label">Checks Receipt</text>
+
+  <rect x="730" y="20" width="230" height="90" rx="12" fill="#aa4455"/>
+  <text x="845" y="58" text-anchor="middle" class="small">No Receipt</text>
+  <text x="845" y="82" text-anchor="middle" class="small">Blocked</text>
+
+  <rect x="730" y="140" width="230" height="90" rx="12" fill="#44aa99"/>
+  <text x="845" y="178" text-anchor="middle" class="small">Valid Receipt</text>
+  <text x="845" y="202" text-anchor="middle" class="small">Approved</text>
+
+  <path class="arrow" d="M250 125 H374"/>
+  <path class="arrow" d="M604 110 H730"/>
+  <path class="arrow" d="M604 140 H730"/>
+</svg>

--- a/assets/gate-blocked.svg
+++ b/assets/gate-blocked.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Deploy Gate Blocked</title>
+  <desc id="desc">Gate symbol in blocked state with severed vertical channel.</desc>
+  <rect x="16" y="16" width="128" height="128" fill="none" stroke="#aa4455" stroke-width="12"/>
+  <line x1="16" y1="80" x2="144" y2="80" stroke="#aa4455" stroke-width="12"/>
+  <line x1="80" y1="16" x2="80" y2="54" stroke="#aa4455" stroke-width="12"/>
+  <line x1="80" y1="106" x2="80" y2="144" stroke="#aa4455" stroke-width="12"/>
+</svg>

--- a/assets/gate-signed.svg
+++ b/assets/gate-signed.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Deploy Gate Approved</title>
+  <desc id="desc">Gate symbol in signed state with connected vertical channel.</desc>
+  <rect x="16" y="16" width="128" height="128" fill="none" stroke="#44aa99" stroke-width="12"/>
+  <line x1="16" y1="80" x2="144" y2="80" stroke="#44aa99" stroke-width="12"/>
+  <line x1="80" y1="16" x2="80" y2="144" stroke="#44aa99" stroke-width="12"/>
+</svg>


### PR DESCRIPTION
## Summary
Enhances deploy-gate README with branded SVG assets and visual flow diagram.

## New Assets
- assets/gate-blocked.svg / gate-signed.svg — gate symbol states
- assets/flow-diagram.svg — PR → Deploy Gate → Blocked/Approved flow
- assets/badge-blocked.svg / badge-approved.svg — shields.io-style status badges

## README Updates
- Hero section with gate-blocked SVG
- How it works section with flow diagram
- Badge usage section

## AC
- [x] Gate symbol SVGs in both states
- [x] Flow diagram showing deploy gate workflow
- [x] Status badges (blocked/approved)
- [x] README hero with visual branding
- [x] All existing content preserved

Closes Roca-Ventures/Breakout-Labs#218