### PR TITLE
ci: add deploy gate to self (dogfood)

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -1,0 +1,26 @@
+name: Deploy Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  permission-check:
+    name: Permission Protocol
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: permission-protocol/deploy-gate@v1
+        with:
+          pp-api-key: ${{ secrets.PP_API_KEY }}
+          pp-request-create-token: ${{ secrets.PP_REQUEST_CREATE_TOKEN }}
+          environment: 'production'
+          capability: 'deploy:main'
+          fail-on-missing: 'true'
+          post-comment: 'true'
+          fail-open-timeout: '30'


### PR DESCRIPTION
Adds the deploy-gate workflow to this repo. Eating our own dogfood.

Once merged, every PR to main requires PP approval before merge.

**Secrets set:** PP_API_KEY ✅ | PP_REQUEST_CREATE_TOKEN ⬜ (need value)

**Next step after merge:** Enable branch protection with 'Permission Protocol' as required check, then Codex opens a test PR for the full loop.