### PR TITLE
fix: use pp-base-url input for review URLs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,7 +98,7 @@ Open a PR to `main`. Deploy Gate always creates/verifies a PP request and posts 
 
 A human must approve before merge.
 
-👉 APPROVE HERE: https://app.permissionprotocol.com/review/dr_abc123
+👉 APPROVE HERE: https://app.permissionprotocol.com/pp/deploy-requests/dr_abc123
 
 After approval, re-run this workflow.
 ═══════════════════════════════════════════════════════════
@@ -107,13 +107,13 @@ After approval, re-run this workflow.
 PR comment (auto-approved / verified):
 ```markdown
 ✅ **Permission Protocol:** Approved
-[View receipt →](https://app.permissionprotocol.com/review/{requestId})
+[View receipt →](https://app.permissionprotocol.com/pp/deploy-requests/{requestId})
 ```
 
 PR comment (approval required):
 ```markdown
 ⏳ **Permission Protocol:** Approval required
-[Review & approve →](https://app.permissionprotocol.com/review/{requestId})
+[Review & approve →](https://app.permissionprotocol.com/pp/deploy-requests/{requestId})
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -218,13 +218,13 @@ Use this when you want custom scope values and auto-request creation in one work
 Auto-approved / verified:
 ```markdown
 ✅ **Permission Protocol:** Approved
-[View receipt →](https://app.permissionprotocol.com/review/{requestId})
+[View receipt →](https://app.permissionprotocol.com/pp/deploy-requests/{requestId})
 ```
 
 Approval required:
 ```markdown
 ⏳ **Permission Protocol:** Approval required
-[Review & approve →](https://app.permissionprotocol.com/review/{requestId})
+[Review & approve →](https://app.permissionprotocol.com/pp/deploy-requests/{requestId})
 ```
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -284,7 +284,7 @@ runs:
         DIAG_KEY_STATUS=$(echo "$HTTP_BODY" | jq -r '.diagnostics.keyStatus // .result.diagnostics.keyStatus // empty' 2>/dev/null || echo "")
 
         if [ -n "$REQUEST_ID" ]; then
-          REVIEW_URL="https://permissionprotocol.com/review/${REQUEST_ID}"
+          REVIEW_URL="${PP_BASE_URL}/pp/deploy-requests/${REQUEST_ID}"
         else
           REVIEW_URL="$APPROVAL_URL"
         fi
@@ -329,7 +329,7 @@ runs:
               echo "     ${REVIEW_URL}"
               echo ""
             else
-              echo "  👉 https://permissionprotocol.com/review"
+              echo "  👉 ${PP_BASE_URL}/pp/deploy-requests"
               echo ""
             fi
             echo "═══════════════════════════════════════════════════════════"


### PR DESCRIPTION
Uses PP_BASE_URL input instead of hardcoded permissionprotocol.com. Fixes wrong path /review/ → /pp/deploy-requests/.