### PR TITLE
fix: skip gate for draft PRs (v2.2.0)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: permission-protocol/deploy-gate@v1
+      - uses: permission-protocol/deploy-gate@v2
         with:
           pp-api-key: ${{ secrets.PP_API_KEY }}
 ```
@@ -62,7 +62,7 @@ jobs:
 Optional (auto-create request on missing receipt):
 
 ```yaml
-      - uses: permission-protocol/deploy-gate@v1
+      - uses: permission-protocol/deploy-gate@v2
         with:
           pp-api-key: ${{ secrets.PP_API_KEY }}
           pp-request-create-token: ${{ secrets.PP_REQUEST_CREATE_TOKEN }}
@@ -189,7 +189,7 @@ Default protected paths: `deploy/` and `.github/workflows/`
 To send different risk metadata signals:
 
 ```yaml
-- uses: permission-protocol/deploy-gate@v1
+- uses: permission-protocol/deploy-gate@v2
   with:
     pp-api-key: ${{ secrets.PP_API_KEY }}
     protected-paths: '^(src/critical/|infra/|k8s/|terraform/)'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-# Version: v2.1.0
+# Version: v2.2.0
 name: 'Deploy Gate'
 description: 'Block AI agents from production deploys without a human-signed Ed25519 receipt. Fails closed by default.'
 author: 'Permission Protocol'
@@ -237,6 +237,23 @@ runs:
             break
           fi
         done < <(normalize_csv_items "${PP_PRODUCTION_ENVIRONMENTS}")
+
+        # Skip the gate entirely for draft PRs — not ready for review/approval.
+        # When the PR is marked ready for review, the gate will run again.
+        if [ -n "${PP_PR_NUMBER}" ]; then
+          IS_DRAFT=$(gh pr view "${PP_PR_NUMBER}" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "⏭️  Skipping Permission Protocol gate — PR #${PP_PR_NUMBER} is a draft"
+            set_output "approved" "true"
+            set_output "receipt-id" ""
+            set_output "decision" "DRAFT_SKIPPED"
+            set_output "error-code" ""
+            set_output "error-message" ""
+            set_output "request-id" ""
+            set_output "approval-url" ""
+            exit 0
+          fi
+        fi
 
         echo "🔍 Collecting changed files for risk metadata..."
         CHANGED_FILES=$(gh pr view "${PP_PR_NUMBER}" --json files --jq '.files[].path' 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

The action had no draft check, so users who trigger their workflow on all `pull_request` events (the common default) would hit the PP gate on draft PRs — even after the app-side webhook fix in permission-protocol/app#531.

## Fix

Added an early check using `gh pr view --json isDraft` before the verify/create flow. If the PR is a draft:
- Exits with `approved=true`, `decision=DRAFT_SKIPPED`
- No deploy request created
- No blocking of the workflow

Uses `GH_TOKEN` which is already in the step environment — no new secrets needed.

When the PR is marked ready for review the workflow re-runs and the gate proceeds normally.

## Version bump

`v2.1.0` → `v2.2.0`