### PR TITLE
Reject carried-forward receipts by default

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,6 +68,17 @@ Optional (auto-create request on missing receipt):
           pp-request-create-token: ${{ secrets.PP_REQUEST_CREATE_TOKEN }}
 ```
 
+Optional (explicitly allow PR-level approval carry-forward):
+
+```yaml
+      - uses: permission-protocol/deploy-gate@v2
+        with:
+          pp-api-key: ${{ secrets.PP_API_KEY }}
+          allow-carry-forward: true
+```
+
+By default, carried-forward approvals fail closed so each pushed PR head needs its own valid receipt.
+
 Commit and push.
 
 ---

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Deploy Gate checks for valid receipt
 - Posts a PR comment with a direct approval link
 - Unblocks the PR instantly after approval
 - Produces a tamper-evident approval receipt
+- Fails closed on carried-forward receipts by default, so a pushed PR update needs a fresh approval for the current head SHA
 
 ## Comparison
 
@@ -114,6 +115,19 @@ Deploy Gate checks for valid receipt
 | GitHub required reviewer only | Partial | No | Often workflow-dependent |
 | PR comments + screenshots | No | No | Open to mutation |
 | Deploy Gate | Yes | Yes (Ed25519 receipt) | Fails closed for production |
+
+## Carry-forward approvals
+
+`v2.2.0` fails closed when the API reports that an approval was carried forward from an earlier PR-level receipt. That keeps the status check bound to the current PR head instead of accepting a receipt from a prior revision after new commits are pushed.
+
+If a repository intentionally wants PR-level carry-forward behavior, opt in explicitly:
+
+```yaml
+- uses: permission-protocol/deploy-gate@v2
+  with:
+    pp-api-key: ${{ secrets.PP_API_KEY }}
+    allow-carry-forward: true
+```
 
 ## Resources
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Redeem receipt on verify (use false for PR gates, true for deploy workflows)'
     required: false
     default: 'false'
+  allow-carry-forward:
+    description: 'Allow a prior PR-level approval to pass after a PR head changes. Defaults to false so each head SHA needs an explicit receipt.'
+    required: false
+    default: 'false'
   protected-paths:
     description: 'Regex pattern for protected paths used for risk assessment metadata (not gating)'
     required: false
@@ -92,6 +96,7 @@ runs:
         PP_ENVIRONMENT: ${{ inputs.environment }}
         PP_CAPABILITY: ${{ inputs.capability }}
         PP_REDEEM: ${{ inputs.redeem }}
+        PP_ALLOW_CARRY_FORWARD: ${{ inputs.allow-carry-forward }}
         PP_FAIL_ON_MISSING: ${{ inputs.fail-on-missing }}
         PP_PROTECTED_PATHS: ${{ inputs.protected-paths }}
         PP_FAIL_OPEN_TIMEOUT: ${{ inputs.fail-open-timeout }}
@@ -213,6 +218,11 @@ runs:
         REDEEM_JSON=false
         if [ "${PP_REDEEM}" = "true" ]; then
           REDEEM_JSON=true
+        fi
+
+        PP_ALLOW_CARRY_FORWARD_NORMALIZED=$(echo "${PP_ALLOW_CARRY_FORWARD:-false}" | tr '[:upper:]' '[:lower:]')
+        if [ "$PP_ALLOW_CARRY_FORWARD_NORMALIZED" != "true" ]; then
+          PP_ALLOW_CARRY_FORWARD_NORMALIZED="false"
         fi
 
         FAIL_ON_MISSING_JSON=true
@@ -365,6 +375,12 @@ runs:
           REVIEW_URL="$APPROVAL_URL"
         fi
 
+        if [ "$VALID" = "true" ] && [ "$CARRIED_FORWARD" = "true" ] && [ "$PP_ALLOW_CARRY_FORWARD_NORMALIZED" != "true" ]; then
+          VALID=false
+          ERROR_CODE="PP_CARRY_FORWARD_DISABLED"
+          ERROR_MESSAGE="Receipt was carried forward from a prior PR approval. Obtain a fresh approval for this exact head SHA or opt into allow-carry-forward."
+        fi
+
         set_output "approved" "$VALID"
         set_output "receipt-id" "$RECEIPT_ID"
         set_output "decision" "$DECISION"
@@ -444,6 +460,18 @@ runs:
             echo "❌ FAIL: Receipt denied"
             if [ -n "$ERROR_MESSAGE" ]; then
               echo "$ERROR_MESSAGE"
+            fi
+            exit 1
+            ;;
+          "PP_CARRY_FORWARD_DISABLED")
+            echo "❌ FAIL: Carried-forward receipt rejected"
+            echo "$ERROR_MESSAGE"
+            echo "Details: repo=${REPO} pr=#${PP_PR_NUMBER} sha=${PP_PR_HEAD_SHA:0:10}"
+            if [ -n "$REQUEST_ID" ]; then
+              echo "Request: ${REQUEST_ID}"
+            fi
+            if [ -n "$REVIEW_URL" ]; then
+              upsert_pr_comment "pending" "$REVIEW_URL"
             fi
             exit 1
             ;;


### PR DESCRIPTION
## Summary

- reject carried-forward receipt responses by default
- add an explicit `allow-carry-forward` opt-in for repos that knowingly want PR-level approval carry-forward
- document the stricter default in the README and install guide

## Why

A carried-forward approval can keep the gate green after the PR head changes. Since the action cannot prove which head SHA the prior approval covered, the safer default is to fail closed and require a fresh approval for the current head unless carry-forward is explicitly enabled.

Related: #46
Bounty: #36

## Validation

- `ruby -ryaml -e 'YAML.load_file("action.yml"); puts "action.yml ok"'
- extracted the embedded action script with GitHub expressions substituted and ran `bash -n`
- `git diff --check`

## Payout

PayPal: jamilurrehman722@gmail.com
