### PR TITLE
Fail closed for draft PR gate skips

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,7 @@ name: Deploy Gate
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 jobs:
@@ -69,6 +70,19 @@ Optional (auto-create request on missing receipt):
 ```
 
 Commit and push.
+
+---
+
+Optional (explicitly keep the old draft-PR skip behavior):
+
+```yaml
+      - uses: permission-protocol/deploy-gate@v2
+        with:
+          pp-api-key: ${{ secrets.PP_API_KEY }}
+          allow-draft-skip: true
+```
+
+By default, draft PRs fail closed because no receipt has been verified yet. If you opt into skipping drafts, keep `ready_for_review` in the workflow trigger so GitHub reruns the gate before the PR can merge.
 
 ---
 
@@ -177,6 +191,7 @@ Error: Request failed with status code 404
 ```yaml
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ name: Deploy Gate
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 jobs:
@@ -106,6 +107,7 @@ Deploy Gate checks for valid receipt
 - Posts a PR comment with a direct approval link
 - Unblocks the PR instantly after approval
 - Produces a tamper-evident approval receipt
+- Fails closed on draft PRs by default, so a skipped draft check cannot stay green after the PR is marked ready for review
 
 ## Comparison
 

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'Post or update a Permission Protocol comment on PRs'
     required: false
     default: 'true'
+  allow-draft-skip:
+    description: 'Allow draft PRs to pass without receipt verification. Defaults to false so required checks cannot stay green after ready_for_review without a rerun.'
+    required: false
+    default: 'false'
 
 outputs:
   approved:
@@ -98,6 +102,7 @@ runs:
         PP_FAIL_MODE: ${{ inputs.fail-mode }}
         PP_PRODUCTION_ENVIRONMENTS: ${{ inputs.production-environments }}
         PP_POST_COMMENT: ${{ inputs.post-comment }}
+        PP_ALLOW_DRAFT_SKIP: ${{ inputs.allow-draft-skip }}
         PP_REPOSITORY: ${{ github.repository }}
         PP_PR_NUMBER: ${{ github.event.pull_request.number }}
         PP_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -225,6 +230,11 @@ runs:
           PP_FAIL_MODE_NORMALIZED="closed"
         fi
 
+        PP_ALLOW_DRAFT_SKIP_NORMALIZED=$(echo "${PP_ALLOW_DRAFT_SKIP:-false}" | tr '[:upper:]' '[:lower:]')
+        if [ "$PP_ALLOW_DRAFT_SKIP_NORMALIZED" != "true" ]; then
+          PP_ALLOW_DRAFT_SKIP_NORMALIZED="false"
+        fi
+
         normalize_csv_items() {
           echo "$1" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]'
         }
@@ -238,20 +248,35 @@ runs:
           fi
         done < <(normalize_csv_items "${PP_PRODUCTION_ENVIRONMENTS}")
 
-        # Skip the gate entirely for draft PRs — not ready for review/approval.
-        # When the PR is marked ready for review, the gate will run again.
+        # Draft PRs are not ready for review/approval, but a successful required
+        # check can remain attached to the head SHA after ready_for_review unless
+        # the workflow explicitly triggers on that event. Fail closed by default.
         if [ -n "${PP_PR_NUMBER}" ]; then
           IS_DRAFT=$(gh pr view "${PP_PR_NUMBER}" --json isDraft --jq '.isDraft' 2>/dev/null || echo "false")
           if [ "$IS_DRAFT" = "true" ]; then
-            echo "⏭️  Skipping Permission Protocol gate — PR #${PP_PR_NUMBER} is a draft"
-            set_output "approved" "true"
+            if [ "$PP_ALLOW_DRAFT_SKIP_NORMALIZED" = "true" ]; then
+              echo "::warning title=Permission Protocol::Draft PR skip is explicitly enabled. Ensure the workflow triggers on ready_for_review so this check reruns before merge."
+              echo "⏭️  Skipping Permission Protocol gate — PR #${PP_PR_NUMBER} is a draft"
+              set_output "approved" "true"
+              set_output "receipt-id" ""
+              set_output "decision" "DRAFT_SKIPPED"
+              set_output "error-code" ""
+              set_output "error-message" ""
+              set_output "request-id" ""
+              set_output "approval-url" ""
+              exit 0
+            fi
+
+            echo "::error title=Permission Protocol::Draft PRs fail closed by default because no receipt has been verified for this head SHA."
+            echo "Mark the PR ready for review and rerun this workflow, or add ready_for_review to the workflow trigger."
+            set_output "approved" "false"
             set_output "receipt-id" ""
-            set_output "decision" "DRAFT_SKIPPED"
-            set_output "error-code" ""
-            set_output "error-message" ""
+            set_output "decision" "DRAFT_BLOCKED"
+            set_output "error-code" "PP_DRAFT_PR_BLOCKED"
+            set_output "error-message" "Draft PR skipped receipt verification. Required checks must not pass until the verify endpoint runs for the current head SHA."
             set_output "request-id" ""
             set_output "approval-url" ""
-            exit 0
+            exit 1
           fi
         fi
 


### PR DESCRIPTION
## Summary

- fail closed by default when a PR is still draft instead of setting `approved=true` without receipt verification
- add `allow-draft-skip: true` as an explicit opt-in for repos that still want the previous skip behavior
- update recommended `pull_request` triggers to include `ready_for_review`

## Why

Fixes #45.
Related to #36.

The previous draft skip path exited `0` before calling `/api/v1/receipts/verify`. With the documented/default `pull_request` trigger, GitHub does not rerun on `ready_for_review`, so a required check could stay green on the same head SHA without any receipt ever being created or verified.

## Validation

- `ruby -ryaml -e 'YAML.load_file("action.yml"); puts "action.yml ok"'`
- extracted the embedded action script, substituted GitHub expressions, and ran `bash -n`
- `git diff --check`
- simulated draft PR branch locally:
  - default `allow-draft-skip=false` exits `1` with `PP_DRAFT_PR_BLOCKED`
  - `allow-draft-skip=true` preserves `DRAFT_SKIPPED` with a warning
